### PR TITLE
sepolicy: Switch to Colt sepolicy

### DIFF
--- a/SEPolicy.mk
+++ b/SEPolicy.mk
@@ -48,4 +48,4 @@ ifneq (,$(filter sdm660 msm8937 msm8953 msm8996 msm8998, $(TARGET_BOARD_PLATFORM
     endif
 endif
 
--include device/xtended/sepolicy/qcom/sepolicy.mk
+-include device/colt/sepolicy/qcom/sepolicy.mk


### PR DESCRIPTION
This Xtended repo is currently not existing.
Switch to Colt sepolicy so we can actually boot ROM.